### PR TITLE
Implement loading comments beyond depth limit

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,6 +28,14 @@
     />
   </div>
 
+  <label>Acquisition option :</label>
+  <div class="form-check form-check-inine">
+    <input type="checkbox" class="form-check-input" id="postLoadComments" />
+    <label class="form-check-label" for="postLoadComments">
+      Load additional comments in seperate request if comment depth greather than 10
+    </label>
+  </div>
+
   <label>Export style :</label>
   <div class="form-check form-check-inline">
     <input class="form-check-input" type="radio" name="exportOption" id="treeOption" checked/>

--- a/script.js
+++ b/script.js
@@ -337,7 +337,7 @@ function displayComment(comment, preexistingDepth = null) {
       loadMoreComments(getFieldUrl(), parentID, currentDepth); ""
     }
     else {
-      output += `${depthTag}comment depth-limit (${currentDepth}) reached\n`;
+      output += `${depthTag}comment depth-limit (${currentDepth}) reached. [view on reddit](${getFieldUrl()}/${parentID})\n`;
     }
   } else {
     output += `${depthTag}deleted\n`;

--- a/script.js
+++ b/script.js
@@ -370,7 +370,7 @@ function displayComment(comment, preexistingDepth = null) {
       loadMoreComments(getFieldUrl(), parentID, currentDepth); ""
     }
     else {
-      output += `${depthTag}comment depth-limit (${currentDepth}) reached\n`;
+      output += `${depthTag}comment depth-limit (${currentDepth}) reached. [view on reddit](${getFieldUrl()}/${parentID})\n`;
     }
   } else {
     output += `${depthTag}deleted\n`;

--- a/script.js
+++ b/script.js
@@ -4,6 +4,7 @@ let output = '';
 let style = 0;
 let escapeNewLine = false;
 let spaceComment = false;
+var postLoadAdditionalComments = false
 var selectedProxy = 'auto';
 
 // CORS Proxy configurations
@@ -42,7 +43,7 @@ function toggleJsonInput() {
 }
 
 const getQueryParamUrl = () => new URLSearchParams(window.location.search).get(
-    'url') ?? null;
+  'url') ?? null;
 const getFieldUrl = () => document.getElementById('url-field').value;
 
 function formatRedditJsonUrl(url) {
@@ -160,7 +161,7 @@ function processRedditData(responseData) {
   const comments = data[1].data.children;
   displayTitle(post);
   output += '\n\n## Comments\n\n';
-  comments.forEach(displayComment);
+  comments.forEach((comment) => displayComment(comment, null));
 
   console.log('Done');
   let output_display = document.getElementById('output-display');
@@ -226,6 +227,20 @@ async function fetchData(url) {
   }
 }
 
+function loadMoreComments(url, parentid, depthInd) {
+  const h2 = new XMLHttpRequest()
+  //to allow the newly loaded comments to appear in the correct place, this call has to be synchronous
+  h2.open('GET', `${url}/${parentid}.json`, false);
+  //setting a desired response type is not supported for non-async calls
+  //h2.responseType = 'json';
+  h2.send();
+
+  //as a response type cannot be set, the result needs to be parsed to JSON manually.
+  const d2 = JSON.parse(h2.responseText)
+  const comments = d2[1].data.children[0].data.replies.data.children;
+  comments.forEach((comment) => displayComment(comment, depthInd));
+}
+
 function setStyle() {
   if (document.getElementById('treeOption').checked) {
     style = 0;
@@ -243,6 +258,12 @@ function setStyle() {
     spaceComment = true;
   } else {
     spaceComment = false;
+  }
+
+  if (document.getElementById('postLoadComments').checked) {
+    postLoadAdditionalComments = true;
+  } else {
+    postLoadAdditionalComments = false;
   }
 
   selectedProxy = document.getElementById('proxySelection').value;
@@ -299,7 +320,7 @@ function download(text, name, type) {
   document.getElementById('copyButton').removeAttribute('disabled');
   let download_button = document.getElementById('downloadButton');
   download_button.removeAttribute('disabled');
-  let file = new Blob([text], {type: type});
+  let file = new Blob([text], { type: type });
   download_button.href = URL.createObjectURL(file);
   download_button.download = name;
 }
@@ -321,39 +342,46 @@ function formatComment(text) {
   }
 }
 
-function displayComment(comment, index) {
+function displayComment(comment, preexistingDepth = null) {
+  let currentDepth = preexistingDepth != null ? preexistingDepth : comment.data.depth;
+  let depthTag
   if (style == 0) {
-    depthTag = '─'.repeat(comment.data.depth);
-    if (depthTag != '') {
-      output += `├${depthTag} `;
+    if (currentDepth > 0) {
+      depthTag = `├${'─'.repeat(currentDepth)} `;
     } else {
-      output += `##### `;
+      depthTag = `##### `;
     }
   } else {
-    depthTag = '\t'.repeat(comment.data.depth);
-    if (depthTag != '') {
-      output += `${depthTag}- `;
+    if (currentDepth > 0) {
+      depthTag = `${'\t'.repeat(currentDepth)}- `;
     } else {
-      output += `- `;
+      depthTag = `- `;
     }
   }
 
   if (comment.data.body) {
     console.log(formatComment(comment.data.body));
-    output += `${formatComment(
-        comment.data.body)} ⏤ by *${comment.data.author}* (↑ ${
-        comment.data.ups
-    }/ ↓ ${comment.data.downs})\n`;
+    output += `${depthTag}${formatComment(
+      comment.data.body)} ⏤ by *${comment.data.author}* (↑ ${comment.data.ups
+      }/ ↓ ${comment.data.downs})\n`;
+  } else if (comment.kind === "more") {
+    let parentID = comment.data.parent_id.substring(3);
+    if (postLoadAdditionalComments) {
+      loadMoreComments(getFieldUrl(), parentID, currentDepth); ""
+    }
+    else {
+      output += `${depthTag}comment depth-limit (${currentDepth}) reached\n`;
+    }
   } else {
-    output += 'deleted \n';
+    output += `${depthTag}deleted\n`;
   }
 
   if (comment.data.replies) {
-    const subComment = comment.data.replies.data.children;
-    subComment.forEach(displayComment);
+    const subComments = comment.data.replies.data.children;
+    subComments.forEach((subComment) => displayComment(subComment, preexistingDepth != null ? preexistingDepth + 1 : null));
   }
 
-  if (comment.data.depth == 0 && comment.data.replies) {
+  if (currentDepth == 0 && comment.data.replies) {
     if (style == 0) {
       output += '└────\n\n';
     }


### PR DESCRIPTION
As reddit will only return up to 10 nested levels of comments in their json API, any comment beyond that must be loaded in a seperate call.

Previously any comment beyond the depth limit would simply have been reported as "deleted".
This adds the option to load those comments individually should the need arise.

I would further suggest you add an editorconfig file (it has been a bit of a fight with my editor to not constantly apply my default formatting to your project) and a license.