### PR TITLE
Implement button to copy output to clipboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
     <input class="form-check-input" type="radio" name="exportOption" id="treeOption" checked/>
     <label class="form-check-label" for="treeOption">Tree style</label>
     <input class="form-check-input" type="radio" name="exportOption" id="listOption"/>
-    <label class="form-check-label" for="exportOption2">List style</label>
+    <label class="form-check-label" for="listOption">List style</label>
   </div>
 
   <label>Export option :</label>
@@ -47,10 +47,11 @@
   </div>
 
   <button class="btn btn-primary" onclick="startExport()">Export</button>
-  <a href="" id="a" download disabled class="btn btn-success">Download markdown file</a>
-  <div id="ouput-block" hidden>
+  <a href="" id="downloadButton" download disabled class="btn btn-success">Download markdown file</a>
+  <button id="copyButton" class="btn btn-success" disabled onclick="copyExport()">Copy to Clipboard</button>
+  <div id="output-block" hidden>
     <h3>Output</h3>
-    <pre id="ouput-display"></pre>
+    <pre id="output-display"></pre>
     <br/>
   </div>
   <footer>

--- a/script.js
+++ b/script.js
@@ -1,9 +1,9 @@
 const http = new XMLHttpRequest();
-var data;
-var output = '';
-var style = 0;
-var escapeNewLine = false;
-var spaceComment = false;
+let data;
+let output = '';
+let style = 0;
+let escapeNewLine = false;
+let spaceComment = false;
 
 const onDocumentReady = () => {
   document.getElementById('url-field').value = getQueryParamUrl();
@@ -32,11 +32,11 @@ function fetchData(url) {
     comments.forEach(displayComment);
 
     console.log('Done');
-    var ouput_display = document.getElementById('ouput-display');
-    var ouput_block = document.getElementById('ouput-block');
-    ouput_block.removeAttribute('hidden');
-    ouput_display.innerHTML = output;
-    download(output, 'output.md', 'text/plain');
+    let output_display = document.getElementById('output-display');
+    let output_block = document.getElementById('output-block');
+    output_block.removeAttribute('hidden');
+    output_display.innerHTML = output;
+    download(document.getElementById('output-display').textContent, 'output.md', 'text/plain');
   };
 }
 
@@ -64,7 +64,7 @@ function startExport() {
   console.log('Start exporting');
   setStyle();
 
-  var url = getFieldUrl();
+  let url = getFieldUrl();
   if (url) {
     fetchData(url);
   } else {
@@ -72,12 +72,25 @@ function startExport() {
   }
 }
 
+async function copyExport() {
+  /*according to https://developer.mozilla.org/en-US/docs/Web/API/Clipboard/writeText
+  this should only work in 'Secure Contexts' (https or localhost/loopback addresses)
+  Since GitHub Pages supports https and getting a certificate for any other host is a 10 minute job
+  I believe it is acceptible to use this despite it's restrictions*/
+  try {
+    await navigator.clipboard.writeText(document.getElementById('output-display').textContent);
+  } catch (error) {
+    console.error(error.message);
+  }
+}
+
 function download(text, name, type) {
-  var a = document.getElementById('a');
-  a.removeAttribute('disabled');
-  var file = new Blob([text], {type: type});
-  a.href = URL.createObjectURL(file);
-  a.download = name;
+  document.getElementById('copyButton').removeAttribute('disabled');
+  let download_button = document.getElementById('downloadButton');
+  download_button.removeAttribute('disabled');
+  let file = new Blob([text], {type: type});
+  download_button.href = URL.createObjectURL(file);
+  download_button.download = name;
 }
 
 function displayTitle(post) {


### PR DESCRIPTION
- Implemented Copy-To-Clipboard using the clipboard API (only available on https sites or localhost)
- fixed incorrect id (exportOption2 vs listOption)
- fixed typo 'ouput' to 'output'
- changed var to let to harden against accidental scope leaks

(this is independent of #4 or #6 and neither requires the other. If you want me to rebase this onto either #4 or #6 instead of merging this, I'd be happy to do so)