### PR TITLE
Implement additional output format for comments

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,6 +28,14 @@
     />
   </div>
 
+  <label>Acquisition option :</label>
+  <div class="form-check form-check-inine">
+    <input type="checkbox" class="form-check-input" id="postLoadComments" />
+    <label class="form-check-label" for="postLoadComments">
+      Load additional comments in seperate request if comment depth greather than 10
+    </label>
+  </div>
+
   <label>Export style :</label>
   <div class="form-check form-check-inline">
     <input class="form-check-input" type="radio" name="exportOption" id="treeOption" checked/>

--- a/index.html
+++ b/index.html
@@ -42,6 +42,8 @@
     <label class="form-check-label" for="treeOption">Tree style</label>
     <input class="form-check-input" type="radio" name="exportOption" id="listOption"/>
     <label class="form-check-label" for="listOption">List style</label>
+    <input class="form-check-input" type="radio" name="exportOption" id="blockOption" />
+    <label class="form-check-label" for="blockOption">Blockquote style</label>
   </div>
 
   <label>Export option :</label>

--- a/script.js
+++ b/script.js
@@ -337,7 +337,7 @@ function displayComment(comment, preexistingDepth = null) {
       loadMoreComments(getFieldUrl(), parentID, currentDepth); ""
     }
     else {
-      output += `${depthTag}comment depth-limit (${currentDepth}) reached\n`;
+      output += `${depthTag}comment depth-limit (${currentDepth}) reached. [view on reddit](${getFieldUrl()}/${parentID})\n`;
     }
   } else {
     output += `${depthTag}deleted\n`;

--- a/script.js
+++ b/script.js
@@ -344,7 +344,8 @@ function displayComment(comment, preexistingDepth = null) {
         they need to be seperated by at least one character not part of either (I chose NBSP)*/
         output += '&amp;nbsp;\n\n'
       }
-      output += `${depthTag}\n${depthTag}#### [**${comment.data.author}** ${comment.data.author_flair_text ? `'***${comment.data.author_flair_text}***' ` : ''}(↑ ${comment.data.ups}/ ↓ ${comment.data.downs}) @${new Date(comment.data.created_utc * 1000).toISOString()}${comment.data.edited ? ` (edited @${new Date(comment.data.edited * 1000).toISOString()})` : ''}](${getFieldUrl()}/${comment.data.id})\n${depthTag}\n${depthTag}${formatComment(comment.data.body).trimEnd().replace(/\n/g, `\n${depthTag}`)}\n`
+      output += `${depthTag}\n${depthTag}#### [**${comment.data.author}** ${comment.data.author_flair_text ? `'***${comment.data.author_flair_text}***' ` : ''}(↑ ${comment.data.ups}/ ↓ ${comment.data.downs}) @${new Date(comment.data.created_utc * 1000).toISOString()}${comment.data.edited ? ` (edited @${new Date(comment.data.edited * 1000).toISOString()})` : ''}](${getFieldUrl()}/${comment.data.id})\n${depthTag}\n${depthTag}${formatComment(comment.data.body).trimEnd().replace(/!&lt;/g, '!&amp;lt;').replace(/&gt;!/g, '&amp;gt;!').replace(/\n/g, `\n${depthTag}`)}\n`;
+      //the !&lt;/&gt;! replacement is to force retain the escaping of </> in spoiler tags to avoid confusion between blockquotes and spoilers
     }
   } else if (comment.kind === "more") {
     let parentID = comment.data.parent_id.substring(3);

--- a/script.js
+++ b/script.js
@@ -378,7 +378,8 @@ function displayComment(comment, preexistingDepth = null) {
         they need to be seperated by at least one character not part of either (I chose NBSP)*/
         output += '&amp;nbsp;\n\n'
       }
-      output += `${depthTag}\n${depthTag}#### [**${comment.data.author}** ${comment.data.author_flair_text ? `'***${comment.data.author_flair_text}***' ` : ''}(↑ ${comment.data.ups}/ ↓ ${comment.data.downs}) @${new Date(comment.data.created_utc * 1000).toISOString()}${comment.data.edited ? ` (edited @${new Date(comment.data.edited * 1000).toISOString()})` : ''}](${getFieldUrl()}/${comment.data.id})\n${depthTag}\n${depthTag}${formatComment(comment.data.body).trimEnd().replace(/\n/g, `\n${depthTag}`)}\n`
+      output += `${depthTag}\n${depthTag}#### [**${comment.data.author}** ${comment.data.author_flair_text ? `'***${comment.data.author_flair_text}***' ` : ''}(↑ ${comment.data.ups}/ ↓ ${comment.data.downs}) @${new Date(comment.data.created_utc * 1000).toISOString()}${comment.data.edited ? ` (edited @${new Date(comment.data.edited * 1000).toISOString()})` : ''}](${getFieldUrl()}/${comment.data.id})\n${depthTag}\n${depthTag}${formatComment(comment.data.body).trimEnd().replace(/!&lt;/g, '!&amp;lt;').replace(/&gt;!/g, '&amp;gt;!').replace(/\n/g, `\n${depthTag}`)}\n`;
+      //the !&lt;/&gt;! replacement is to force retain the escaping of </> in spoiler tags to avoid confusion between blockquotes and spoilers
     }
   } else if (comment.kind === "more") {
     let parentID = comment.data.parent_id.substring(3);

--- a/script.js
+++ b/script.js
@@ -4,7 +4,7 @@ let output = '';
 let style = 0;
 let escapeNewLine = false;
 let spaceComment = false;
-var postLoadAdditionalComments = false
+let postLoadAdditionalComments = false
 var selectedProxy = 'auto';
 
 // CORS Proxy configurations
@@ -245,8 +245,10 @@ function loadMoreComments(url, parentid, depthInd) {
 function setStyle() {
   if (document.getElementById('treeOption').checked) {
     style = 0;
-  } else {
+  } else if (document.getElementById('listOption').checked) {
     style = 1;
+  } else {
+    style = 2
   }
 
   if (document.getElementById('escapeNewLine').checked) {
@@ -352,34 +354,56 @@ function displayComment(comment, preexistingDepth = null) {
     } else {
       depthTag = `##### `;
     }
-  } else {
+  } else if (style == 1) {
     if (currentDepth > 0) {
       depthTag = `${'\t'.repeat(currentDepth)}- `;
     } else {
       depthTag = `- `;
     }
   }
+  else {
+    depthTag = '>'.repeat(currentDepth + 1);
+  }
 
   if (comment.data.body) {
     console.log(formatComment(comment.data.body));
-    output += `${depthTag}${formatComment(
-      comment.data.body)} ⏤ by *${comment.data.author}* (↑ ${comment.data.ups
-      }/ ↓ ${comment.data.downs})\n`;
+    if (style < 2) {
+      output += `${depthTag}${formatComment(
+        comment.data.body)} ⏤ by *${comment.data.author}* (↑ ${comment.data.ups
+        }/ ↓ ${comment.data.downs})\n`;
+    }
+    else {
+      if (currentDepth == 0) {
+        /*to make it unambiguous if two block quotes should be seperate or one and the same
+        they need to be seperated by at least one character not part of either (I chose NBSP)*/
+        output += '&amp;nbsp;\n\n'
+      }
+      output += `${depthTag}\n${depthTag}#### [**${comment.data.author}** ${comment.data.author_flair_text ? `'***${comment.data.author_flair_text}***' ` : ''}(↑ ${comment.data.ups}/ ↓ ${comment.data.downs}) @${new Date(comment.data.created_utc * 1000).toISOString()}${comment.data.edited ? ` (edited @${new Date(comment.data.edited * 1000).toISOString()})` : ''}](${getFieldUrl()}/${comment.data.id})\n${depthTag}\n${depthTag}${formatComment(comment.data.body).trimEnd().replace(/\n/g, `\n${depthTag}`)}\n`
+    }
   } else if (comment.kind === "more") {
     let parentID = comment.data.parent_id.substring(3);
     if (postLoadAdditionalComments) {
       loadMoreComments(getFieldUrl(), parentID, currentDepth); ""
     }
     else {
-      output += `${depthTag}comment depth-limit (${currentDepth}) reached. [view on reddit](${getFieldUrl()}/${parentID})\n`;
+      output += `${depthTag}${style == 2 ? `\n${depthTag}#### ` : ''}comment depth-limit (${currentDepth}) reached. [view on reddit](${getFieldUrl()}/${parentID})\n`;
     }
   } else {
-    output += `${depthTag}deleted\n`;
+    output += `${depthTag}${style == 2 ? `\n${depthTag}#### ` : ''}deleted\n`;
   }
 
   if (comment.data.replies) {
     const subComments = comment.data.replies.data.children;
     subComments.forEach((subComment) => displayComment(subComment, preexistingDepth != null ? preexistingDepth + 1 : null));
+  }
+  if (style == 2) {
+    /*do note, this is NOT depthTag, it has one fewer symbol
+    this is required forcibly split the block-quotes for two comments on the same level.
+    It technically generates more  markers than strictly necessary,
+    but those extra ones are not harmful, and depending on your interpretation,
+    can even more sematically correct than if they were absent*/
+    output += '>'.repeat(currentDepth);
+    output += '\n'
   }
 
   if (currentDepth == 0 && comment.data.replies) {


### PR DESCRIPTION
I have implemented a cleaner way to display comments in markdown using nested blockquotes.

This PR relies on #4 (in sofar as it incorporates the commits present there) as the differentiation between deleted comments and those simply nested too deeply is relevant for formatting the output.

If you'd be open to merging this I'd recommed just closing #4 and merging this here instead [though even if you do that, I'd still be glad if you could still consider my remarks on license and editorconfig I made in #4].

#5 is still completely independent from this.